### PR TITLE
Added compatibility for ATMega 1284p

### DIFF
--- a/utility/w5200.h
+++ b/utility/w5200.h
@@ -345,7 +345,7 @@ private:
   uint16_t RBASE[SOCKETS]; // Rx buffer base address
 
 private:
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega1284P__)
   inline static void initSS()    { DDRB  |=  _BV(4); };
   inline static void setSS()     { PORTB &= ~_BV(4); };
   inline static void resetSS()   { PORTB |=  _BV(4); };


### PR DESCRIPTION
Hi,

I'm using the Wiz820io with the ATMega1284 on Arduino with MightyCore (https://github.com/MCUdude/MightyCore).

I've simply added the ATMega1284 constant, because it has the same SPI definitions as the ATMega2560.

Would be glad if you merge.

Cheers,
Patrik